### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/ass.rs
+++ b/src/ass.rs
@@ -359,7 +359,7 @@ impl SpanSet {
 
         while line <= end_line {
             if last_b == linespan.char_st {
-                out.push_str(&format!(" {:3.}  ", line));
+                out.push_str(&format!(" {:3}  ", line));
             }
 
             if cur > spans.len() || last_b < curspan.char_st {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See rust-lang/rust#131159 and rust-lang/rust#136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.